### PR TITLE
Delete use of props.key. Fixes #465

### DIFF
--- a/src/js/Dialogs/DialogFooter.js
+++ b/src/js/Dialogs/DialogFooter.js
@@ -52,7 +52,7 @@ export default class DialogFooter extends PureComponent {
       const button = Children.only(action);
 
       return cloneElement(action, {
-        key: button.props.key || index,
+        key: index,
         className: cn('md-btn--dialog', button.props.className),
       });
     }


### PR DESCRIPTION
Fix react warning:
      Warning: ButtonTooltipedInked: `key` is not a prop. Trying to access it will result in `undefined` being returned. If you need to access the same value within the child component, you should pass it as a different prop. (https://fb.me/react-special-props)
